### PR TITLE
Better handling of --annotate_hit_tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.emapper.*
 *.swp
 emappertmp*
+data/*
+!.gitkeep

--- a/emapper.py
+++ b/emapper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import os
+import errno
 import time
 import cPickle
 import multiprocessing
@@ -185,6 +186,9 @@ def main(args):
     else:
         output_files = [hmm_hits_file, seed_orthologs_file, annot_file]
 
+    # convert to absolute path before changing directory
+    if args.annotate_hits_table:
+        args.annotate_hits_table = os.path.abspath(args.annotate_hits_table)
     # force user to decide what to do with existing files
     os.chdir(args.output_dir)
     files_present = set([pexists(fname) for fname in output_files])
@@ -233,6 +237,10 @@ def main(args):
     if not args.no_annot:
         annota.connect()
         if args.annotate_hits_table:
+            if not os.path.exists(args.annotate_hits_table):
+                raise IOError(errno.ENOENT,
+                              os.strerror(errno.ENOENT),
+                              args.annotate_hits_table)
             annotate_hits_file(args.annotate_hits_table, annot_file, hmm_hits_file, args)
         elif args.db == 'viruses':
             annotate_hmm_matches(hmm_hits_file, hmm_hits_file+'.annotations', args)


### PR DESCRIPTION
Quick fix for #86

This pull request adds error handling when file pointed by `--annotate_hits_table` is missing, and also make sure the file can be found if the argument is used in combination with `--output_dir`

I think the best way to solve this would be to remove all the `os.chdir()` stuff along the code and to actually use `os.path.join()` where it is needed, but this could create several side effects that I cannot test for right now.