### PR TITLE
Fix: Update obsolete URLs for database download

### DIFF
--- a/download_eggnog_data.py
+++ b/download_eggnog_data.py
@@ -12,10 +12,10 @@ from eggnogmapper.version import __DB_VERSION__, __NOVEL_FAMS_DB_VERSION__
 if sys.version_info < (3,7):
     sys.exit('Sorry, Python < 3.7 is not supported')
     
-BASE_URL = f'http://eggnogdb.embl.de/download/emapperdb-{__DB_VERSION__}'
+BASE_URL = f'http://eggnog5.embl.de/download/emapperdb-{__DB_VERSION__}'
 EGGNOG_URL = f'http://eggnog5.embl.de/download/eggnog_5.0/per_tax_level'
 EGGNOG_DOWNLOADS_URL = 'http://eggnog5.embl.de/#/app/downloads'
-NOVEL_FAMS_BASE_URL = f'http://eggnogdb.embl.de/download/novel_fams-{__NOVEL_FAMS_DB_VERSION__}'
+NOVEL_FAMS_BASE_URL = f'http://eggnog5.embl.de/download/novel_fams-{__NOVEL_FAMS_DB_VERSION__}'
 
 class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
                       argparse.RawDescriptionHelpFormatter):


### PR DESCRIPTION
I found an error with the URLs in  "download_eggnog_data.py" script, and fixed it. 

You can also use wget to download the databases from the source directly:
```
wget http://eggnog5.embl.de/download/emapperdb-5.0.2/eggnog.db.gz
wget http://eggnog5.embl.de/download/emapperdb-5.0.2/eggnog.taxa.tar.gz
wget http://eggnog5.embl.de/download/emapperdb-5.0.2/eggnog_proteins.dmnd.gz
```
You would need to decompress them. 
```
gunzip eggnog.db.gz
tar -xzvf eggnog.taxa.tar.gz
gunzip eggnog_proteins.dmnd.gz
```

However doing this is more tedious than just running the script.
